### PR TITLE
[feat] Showing and hiding stashed workspace implementation.

### DIFF
--- a/src/register_action.rs
+++ b/src/register_action.rs
@@ -7,8 +7,15 @@ pub enum RegisterStatus {
 
 use crate::state::{Register, RegisterUpdate, State};
 use niri_ipc::{
-    Action::{FocusWindow, MoveWindowToMonitor, MoveWindowToWorkspace},
-    Request, Response,
+    // This Addition of feature is experminetal as it is in the niri 25.01.
+    // So things outside from that this current code will be backward incompatible.
+    Action::{
+        FocusWindow, MoveWindowToMonitor, MoveWindowToWorkspace, SetWorkspaceName,
+        UnsetWorkspaceName,
+    },
+    Request,
+    Response,
+    WorkspaceReferenceArg,
     socket::Socket,
 };
 
@@ -24,11 +31,44 @@ pub fn stash(socket: &mut Socket, state: &State, register_number: Option<i32>) {
             return;
         }
     };
-    let Some(stash_workspace) = workspaces
+
+    //  We can use set-workspace-name and unset-workspace-name
+    let stash_workspace_id = match workspaces
         .iter()
         .find(|workspace| workspace.name.as_deref() == Some("stash"))
-    else {
-        return;
+    {
+        Some(stash) => stash.id,
+        None => {
+            let target = match socket.send(Request::FocusedOutput) {
+                Ok(Ok(Response::FocusedOutput(Some(output)))) => Some(output.name),
+                _ => None,
+            };
+
+            // Lets pick to the last *unnamed* workspace.
+            let last_workspace = if let Some(ref output_name) = target {
+                workspaces
+                    .iter()
+                    .filter(|w| {
+                        w.output.as_deref() == Some(output_name.as_str()) && w.name.is_none()
+                    })
+                    .max_by_key(|w| w.idx)
+            } else {
+                workspaces
+                    .iter()
+                    .filter(|w| w.name.is_none())
+                    .max_by_key(|w| w.idx)
+            };
+            let Some(last) = last_workspace else {
+                return;
+            };
+
+            let _ = socket.send(Request::Action(SetWorkspaceName {
+                name: "stash".to_string(),
+                workspace: Some(WorkspaceReferenceArg::Id(last.id)),
+            }));
+
+            last.id
+        }
     };
     for window in windows.iter().filter(|window| match register_number {
         Some(register_num) => state
@@ -42,7 +82,7 @@ pub fn stash(socket: &mut Socket, state: &State, register_number: Option<i32>) {
     }) {
         let move_action = MoveWindowToWorkspace {
             window_id: Some(window.id),
-            reference: niri_ipc::WorkspaceReferenceArg::Id(stash_workspace.id),
+            reference: niri_ipc::WorkspaceReferenceArg::Id(stash_workspace_id),
             focus: false,
         };
         let _ = socket.send(Request::Action(move_action));
@@ -52,6 +92,32 @@ pub fn stash(socket: &mut Socket, state: &State, register_number: Option<i32>) {
 pub enum RegisterInformation<'a> {
     Id(i32),
     Register(&'a Register),
+}
+
+pub fn clean_status(socket: &mut Socket) {
+    let (windows, workspaces) = match (
+        socket.send(Request::Windows),
+        socket.send(Request::Workspaces),
+    ) {
+        (Ok(Ok(Response::Windows(windows))), Ok(Ok(Response::Workspaces(workspaces)))) => {
+            (windows, workspaces)
+        }
+        _ => return,
+    };
+
+    let Some(stash) = workspaces
+        .iter()
+        .find(|w| w.name.as_deref() == Some("stash"))
+    else {
+        return;
+    };
+
+    let stash_contains_windows = windows.iter().any(|w| w.workspace_id == Some(stash.id));
+    if !stash_contains_windows {
+        let _ = socket.send(Request::Action(UnsetWorkspaceName {
+            reference: Some(WorkspaceReferenceArg::Id(stash.id)),
+        }));
+    }
 }
 
 pub fn summon(
@@ -106,6 +172,8 @@ pub fn summon(
         id: (found_register.window_id),
     };
     let _ = socket.send(Request::Action(focus_action));
+
+    clean_status(socket);
     Ok(())
 }
 

--- a/src/target_action.rs
+++ b/src/target_action.rs
@@ -1,10 +1,11 @@
 use std::io::Result;
 
-use niri_ipc::{Request, Response, Window, socket::Socket};
+use niri_ipc::{Request, Response, Window, WorkspaceReferenceArg, socket::Socket};
 
 use niri_ipc::Action::{FocusWindow, MoveWindowToMonitor, MoveWindowToWorkspace};
 
 use crate::args::Property;
+use crate::register_action::clean_status;
 use crate::target_action;
 use crate::utils::{set_floating, set_tiling};
 
@@ -58,10 +59,50 @@ pub fn match_window_by_property(window: &Window, property: &Property) -> bool {
     }
 }
 
-pub fn stash_window(socket: &mut Socket, window: &Window, workspace_id: u64) {
+fn get_or_create_stash_workspace(socket: &mut Socket) -> Option<u64> {
+    let Ok(Ok(Response::Workspaces(workspaces))) = socket.send(Request::Workspaces) else {
+        return None;
+    };
+
+    if let Some(stash) = workspaces
+        .iter()
+        .find(|w| w.name.as_deref() == Some("stash"))
+    {
+        return Some(stash.id);
+    }
+
+    let target_output = match socket.send(Request::FocusedOutput) {
+        Ok(Ok(Response::FocusedOutput(Some(output)))) => Some(output.name),
+        _ => None,
+    };
+
+    let last = if let Some(ref output_name) = target_output {
+        workspaces
+            .iter()
+            .filter(|w| w.output.as_deref() == Some(output_name.as_str()) && w.name.is_none())
+            .max_by_key(|w| w.idx)
+    } else {
+        workspaces
+            .iter()
+            .filter(|w| w.name.is_none())
+            .max_by_key(|w| w.idx)
+    }?;
+
+    let _ = socket.send(Request::Action(niri_ipc::Action::SetWorkspaceName {
+        name: "stash".to_string(),
+        workspace: Some(WorkspaceReferenceArg::Id(last.id)),
+    }));
+
+    Some(last.id)
+}
+
+pub fn stash_window(socket: &mut Socket, window: &Window) {
+    let Some(stash_id) = get_or_create_stash_workspace(socket) else {
+        return;
+    };
     let _ = socket.send(Request::Action(niri_ipc::Action::MoveWindowToWorkspace {
         window_id: Some(window.id),
-        reference: niri_ipc::WorkspaceReferenceArg::Id(workspace_id),
+        reference: WorkspaceReferenceArg::Id(stash_id),
         focus: false,
     }));
 }
@@ -78,12 +119,14 @@ pub fn summon_window(socket: &mut Socket, window: &Window, workspace_id: u64) ->
     let _ = socket.send(Request::Action(move_action));
     let move_action = MoveWindowToWorkspace {
         window_id: Some(window.id),
-        reference: niri_ipc::WorkspaceReferenceArg::Id(workspace_id),
-        focus: (true),
+        reference: WorkspaceReferenceArg::Id(workspace_id),
+        focus: true,
     };
     let _ = socket.send(Request::Action(move_action));
-    let focus_action = FocusWindow { id: (window.id) };
+    let focus_action = FocusWindow { id: window.id };
     let _ = socket.send(Request::Action(focus_action));
+
+    clean_status(socket);
     Ok(())
 }
 
@@ -103,21 +146,24 @@ pub fn handle_target(
         return Ok(());
     };
 
-    let Some(stash_workspace) = workspaces
+    let current_workspace_id = current_workspace.id;
+    // Find existing stash workspace for the lookup — we don't create it here,
+    // only stash_window() creates it on demand when we actually need to stash.
+    let stash_workspace_id = workspaces
         .iter()
-        .find(|workspace| Some("stash") == workspace.name.as_deref())
-    else {
-        return Ok(());
-    };
+        .find(|w| w.name.as_deref() == Some("stash"))
+        .map(|w| w.id)
+        .unwrap_or(0);
+
     let window_target_information =
-        get_windows_by_property(&mut socket, &property, stash_workspace.id);
+        get_windows_by_property(&mut socket, &property, stash_workspace_id);
 
     if let Some(command) = spawn
         && window_target_information.windows.is_empty()
     {
         target_action::spawn(&mut socket, command);
         return Ok(());
-    };
+    }
 
     if !window_target_information.windows.is_empty() {
         // tl;dr if there are ny matching windows found in the stash workspace, we simply move
@@ -125,7 +171,7 @@ pub fn handle_target(
         // otherwise we'll be playing switcheroo if matched windows exist in stash and focused simultaneously
         if window_target_information.found_in_stash {
             for window in window_target_information.windows {
-                target_action::summon_window(&mut socket, &window, current_workspace.id)?;
+                target_action::summon_window(&mut socket, &window, current_workspace_id)?;
                 if as_float {
                     set_floating(&mut socket, window.id);
                 }
@@ -135,7 +181,7 @@ pub fn handle_target(
                 if animations && window.is_floating {
                     set_tiling(&mut socket, window.id);
                 }
-                target_action::stash_window(&mut socket, &window, stash_workspace.id);
+                target_action::stash_window(&mut socket, &window);
             }
         }
     }


### PR DESCRIPTION
 @argosnothing 
[feat] Showing and hiding stashed workspace implementation.

#10 This implementation is a working implementation of the basic stashing but also just bare in mind I test it on bare metal niri setup directly from source.

This version does require to use the niri 25.01 `set-workspace-name` and `unset-workspace-name` api. 

Let me know if there is anything I should add it. 